### PR TITLE
cmd/check-imports: new command to check imports in Gonum

### DIFF
--- a/cmd/check-imports/main.go
+++ b/cmd/check-imports/main.go
@@ -1,0 +1,58 @@
+// Copyright ©2018 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Command check-imports inspects a source tree for blacklisted imports.
+//
+// Example:
+//
+//  $> check-imports -b="github.com/gonum/.*,math/rand"
+//  $> check-imports -b="github.com/gonum/.*,math/rand" .
+//  $> check-imports -b="github.com/gonum/.*,math/rand" /some/dir /other/dir
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+	"strings"
+
+	"gonum.org/v1/tools/imports"
+)
+
+func main() {
+	log.SetPrefix("check-imports: ")
+	log.SetFlags(0)
+
+	blist := flag.String("b", "", "comma-separated list of blacklisted imports")
+
+	flag.Parse()
+
+	if *blist == "" {
+		flag.Usage()
+		log.Fatalf("missing blacklist of imports")
+	}
+
+	switch flag.NArg() {
+	case 0:
+		dir, err := os.Getwd()
+		if err != nil {
+			log.Fatalf("could not retrieve current working directory: %v", err)
+		}
+		log.Printf("analyzing imports under %q...", dir)
+		err = imports.CheckBlacklisted(dir, strings.Split(*blist, ","))
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Printf("analyzing imports under %q... [OK]", dir)
+	default:
+		for _, dir := range flag.Args() {
+			log.Printf("analyzing imports under %q...", dir)
+			err := imports.CheckBlacklisted(dir, strings.Split(*blist, ","))
+			if err != nil {
+				log.Fatal(err)
+			}
+			log.Printf("analyzing imports under %q... [OK]", dir)
+		}
+	}
+}

--- a/imports/imports.go
+++ b/imports/imports.go
@@ -1,0 +1,126 @@
+// Copyright ©2018 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package imports provides an API to check whether code imports blacklisted packages.
+package imports // import "gonum.org/v1/tools/imports"
+
+import (
+	"fmt"
+	"go/parser"
+	"go/token"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// CheckBlacklisted analyzes all Go files under dir for deprecated and
+// blacklisted imports.
+// If CheckBlacklisted encounters multiple files importing deprecated imports, the
+// first error is returned to the user.
+func CheckBlacklisted(dir string, blacklist []string) error {
+	// TODO: handle multiple errors.
+	// TODO: add a limit of the number of errors to handle before bailing out.
+
+	list, err := str2RE(blacklist)
+	if err != nil {
+		return err
+	}
+
+	var files []string
+	err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		switch {
+		case info.IsDir():
+			switch info.Name() {
+			case "testdata":
+				return filepath.SkipDir
+			}
+		default:
+			if filepath.Ext(info.Name()) != ".go" {
+				return nil
+			}
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	fset := token.NewFileSet()
+	for _, fname := range files {
+		e := process(fname, fset, list)
+		if e != nil {
+			if err == nil {
+				err = e
+			}
+		}
+	}
+	return err
+}
+
+func process(fname string, fset *token.FileSet, blacklist []*regexp.Regexp) error {
+	src, err := ioutil.ReadFile(fname)
+	if err != nil {
+		return err
+	}
+	return checkImports(fset, src, fname, blacklist)
+}
+
+func checkImports(fset *token.FileSet, src []byte, fname string, blacklist []*regexp.Regexp) error {
+	f, err := parser.ParseFile(fset, fname, src, parser.ImportsOnly)
+	if err != nil {
+		return err
+	}
+
+	imp := Error{File: fname}
+	for _, s := range f.Imports {
+		path := strings.Trim(s.Path.Value, `"`)
+		if blacklisted(path, blacklist) {
+			imp.Imports = append(imp.Imports, path)
+		}
+	}
+	if len(imp.Imports) > 0 {
+		return imp
+	}
+	return nil
+}
+
+func blacklisted(path string, blacklist []*regexp.Regexp) bool {
+	for _, v := range blacklist {
+		if v.MatchString(path) {
+			return true
+		}
+	}
+	return false
+}
+
+func str2RE(vs []string) ([]*regexp.Regexp, error) {
+	var (
+		err error
+		o   = make([]*regexp.Regexp, len(vs))
+	)
+	for i, v := range vs {
+		o[i], err = regexp.Compile(v)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return o, nil
+}
+
+// Error stores information about a deprecated import in a Go file.
+type Error struct {
+	File    string
+	Imports []string
+}
+
+func (e Error) Error() string {
+	return fmt.Sprintf(
+		"%s: deprecated imports: %v",
+		e.File,
+		strings.Join(e.Imports, ", "),
+	)
+}

--- a/imports/imports_test.go
+++ b/imports/imports_test.go
@@ -1,0 +1,82 @@
+// Copyright ©2018 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package imports
+
+import (
+	"fmt"
+	"go/token"
+	"reflect"
+	"testing"
+)
+
+var blacklist = []string{
+	"github.com/gonum/.*", // prefer gonum.org/v1/gonum
+	"math/rand",           // prefer golang.org/x/exp/rand
+}
+
+func TestCheck(t *testing.T) {
+	blacklist, err := str2RE(blacklist)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fset := token.NewFileSet()
+	for _, tc := range []struct {
+		pkg string
+		err error
+	}{
+		{
+			pkg: "math/rand",
+			err: Error{
+				File:    "file.go",
+				Imports: []string{"math/rand"},
+			},
+		},
+		{
+			pkg: "math",
+			err: nil,
+		},
+		{
+			pkg: "github.com/gonum/",
+			err: Error{
+				File:    "file.go",
+				Imports: []string{"github.com/gonum/"},
+			},
+		},
+		{
+			pkg: "github.com/gonum/floats",
+			err: Error{
+				File:    "file.go",
+				Imports: []string{"github.com/gonum/floats"},
+			},
+		},
+		{
+			pkg: "github.com/gonum/plot",
+			err: Error{
+				File:    "file.go",
+				Imports: []string{"github.com/gonum/plot"},
+			},
+		},
+		{
+			pkg: "gonum.org/v1/gonum/floats",
+			err: nil,
+		},
+		{
+			pkg: "gonum.org/v1/plot",
+			err: nil,
+		},
+		{
+			pkg: "github.com/gonumnum/floats",
+			err: nil,
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			src := fmt.Sprintf("package foo\nimport _ %q\n", tc.pkg)
+			err := checkImports(fset, []byte(src), "file.go", blacklist)
+			if !reflect.DeepEqual(err, tc.err) {
+				t.Fatalf("error\ngot= %v\nwant=%v", err, tc.err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This CL adds a new command "check-imports" to enforce some rules about
imports in the Gonum project.

Namely, this command checks whether Go packages are importing deprecated
or blacklisted packages.

Updates gonum/gonum#467.