### PR TITLE
imports: anchor regexps to ends of patterns

### DIFF
--- a/imports/imports.go
+++ b/imports/imports.go
@@ -103,6 +103,12 @@ func str2RE(vs []string) ([]*regexp.Regexp, error) {
 		o   = make([]*regexp.Regexp, len(vs))
 	)
 	for i, v := range vs {
+		if !strings.HasPrefix(v, "^") {
+			v = "^" + v
+		}
+		if !strings.HasSuffix(v, "$") {
+			v += "$"
+		}
 		o[i], err = regexp.Compile(v)
 		if err != nil {
 			return nil, err

--- a/imports/imports_test.go
+++ b/imports/imports_test.go
@@ -34,6 +34,10 @@ func TestCheck(t *testing.T) {
 			},
 		},
 		{
+			pkg: "math/rands",
+			err: nil,
+		},
+		{
 			pkg: "math",
 			err: nil,
 		},


### PR DESCRIPTION
Please take a look.

Fixes #6.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
