### PR TITLE
imports: add handling of whitelists

### DIFF
--- a/cmd/check-imports/main.go
+++ b/cmd/check-imports/main.go
@@ -2,13 +2,17 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Command check-imports inspects a source tree for blacklisted imports.
+// Command check-imports inspects a source tree for imports satisfying a
+// whitelist/blacklist scheme. If a whitelist in included, packages from
+// the standard library are included. The order of application is whitelist
+// then blacklist.
 //
 // Example:
 //
 //  $> check-imports -b="github.com/gonum/.*,math/rand"
 //  $> check-imports -b="github.com/gonum/.*,math/rand" .
 //  $> check-imports -b="github.com/gonum/.*,math/rand" /some/dir /other/dir
+//  $> check-imports -w="github.com/.*" -b="github.com/gonum/.*" /some/dir /other/dir
 package main
 
 import (
@@ -24,13 +28,14 @@ func main() {
 	log.SetPrefix("check-imports: ")
 	log.SetFlags(0)
 
+	wlist := flag.String("w", "", "comma-separated list of whitelisted imports")
 	blist := flag.String("b", "", "comma-separated list of blacklisted imports")
 
 	flag.Parse()
 
-	if *blist == "" {
+	if *wlist == "" && *blist == "" {
 		flag.Usage()
-		log.Fatalf("missing blacklist of imports")
+		log.Fatalf("missing white/blacklist of imports")
 	}
 
 	switch flag.NArg() {
@@ -40,7 +45,7 @@ func main() {
 			log.Fatalf("could not retrieve current working directory: %v", err)
 		}
 		log.Printf("analyzing imports under %q...", dir)
-		err = imports.CheckBlacklisted(dir, strings.Split(*blist, ","))
+		err = imports.CheckAllowed(dir, split(*wlist), split(*blist))
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -48,11 +53,18 @@ func main() {
 	default:
 		for _, dir := range flag.Args() {
 			log.Printf("analyzing imports under %q...", dir)
-			err := imports.CheckBlacklisted(dir, strings.Split(*blist, ","))
+			err := imports.CheckAllowed(dir, split(*wlist), split(*blist))
 			if err != nil {
 				log.Fatal(err)
 			}
 			log.Printf("analyzing imports under %q... [OK]", dir)
 		}
 	}
+}
+
+func split(list string) []string {
+	if len(list) == 0 {
+		return nil
+	}
+	return strings.Split(list, ",")
 }

--- a/cmd/check-imports/main.go
+++ b/cmd/check-imports/main.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // Command check-imports inspects a source tree for imports satisfying a
-// whitelist/blacklist scheme. If a whitelist in included, packages from
+// whitelist/blacklist scheme. If a whitelist is included, packages from
 // the standard library are included. The order of application is whitelist
 // then blacklist.
 //

--- a/cmd/check-imports/main.go
+++ b/cmd/check-imports/main.go
@@ -7,6 +7,9 @@
 // the standard library are included. The order of application is whitelist
 // then blacklist.
 //
+// If the standard library is not wanted in the whitelist, the pseudo-package
+// "-std" can be specified in the whitelist to exclude it.
+//
 // Example:
 //
 //  $> check-imports -b="github.com/gonum/.*,math/rand"

--- a/imports/imports.go
+++ b/imports/imports.go
@@ -2,11 +2,13 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package imports provides an API to check whether code imports blacklisted packages.
+// Package imports provides an API to check whether code imports packages
+// according to a whitelist/blacklist scheme.
 package imports // import "gonum.org/v1/tools/imports"
 
 import (
 	"fmt"
+	"go/build"
 	"go/parser"
 	"go/token"
 	"io/ioutil"
@@ -16,15 +18,27 @@ import (
 	"strings"
 )
 
-// CheckBlacklisted analyzes all Go files under dir for deprecated and
-// blacklisted imports.
-// If CheckBlacklisted encounters multiple files importing deprecated imports, the
+// CheckAllowed analyzes all Go files under dir for imports based on a
+// whitelist/blacklist scheme.
+// If CheckAllowed encounters multiple files importing non-allowed imports, the
 // first error is returned to the user.
-func CheckBlacklisted(dir string, blacklist []string) error {
+func CheckAllowed(dir string, whitelist, blacklist []string) error {
 	// TODO: handle multiple errors.
 	// TODO: add a limit of the number of errors to handle before bailing out.
 
-	list, err := str2RE(blacklist)
+	if len(whitelist) == 0 && len(blacklist) == 0 {
+		return nil
+	}
+
+	whitelist, err := includeStd(whitelist)
+	if err != nil {
+		return err
+	}
+	whitepat, err := str2RE(whitelist)
+	if err != nil {
+		return err
+	}
+	blackpat, err := str2RE(blacklist)
 	if err != nil {
 		return err
 	}
@@ -51,7 +65,7 @@ func CheckBlacklisted(dir string, blacklist []string) error {
 
 	fset := token.NewFileSet()
 	for _, fname := range files {
-		e := process(fname, fset, list)
+		e := process(fname, fset, whitepat, blackpat)
 		if e != nil {
 			if err == nil {
 				err = e
@@ -61,15 +75,15 @@ func CheckBlacklisted(dir string, blacklist []string) error {
 	return err
 }
 
-func process(fname string, fset *token.FileSet, blacklist []*regexp.Regexp) error {
+func process(fname string, fset *token.FileSet, whitelist, blacklist []*regexp.Regexp) error {
 	src, err := ioutil.ReadFile(fname)
 	if err != nil {
 		return err
 	}
-	return checkImports(fset, src, fname, blacklist)
+	return checkImports(fset, src, fname, whitelist, blacklist)
 }
 
-func checkImports(fset *token.FileSet, src []byte, fname string, blacklist []*regexp.Regexp) error {
+func checkImports(fset *token.FileSet, src []byte, fname string, whitelist, blacklist []*regexp.Regexp) error {
 	f, err := parser.ParseFile(fset, fname, src, parser.ImportsOnly)
 	if err != nil {
 		return err
@@ -78,7 +92,10 @@ func checkImports(fset *token.FileSet, src []byte, fname string, blacklist []*re
 	imp := Error{File: fname}
 	for _, s := range f.Imports {
 		path := strings.Trim(s.Path.Value, `"`)
-		if blacklisted(path, blacklist) {
+		if len(whitelist) != 0 && !listed(path, whitelist) {
+			imp.Imports = append(imp.Imports, path)
+		}
+		if listed(path, blacklist) {
 			imp.Imports = append(imp.Imports, path)
 		}
 	}
@@ -88,8 +105,8 @@ func checkImports(fset *token.FileSet, src []byte, fname string, blacklist []*re
 	return nil
 }
 
-func blacklisted(path string, blacklist []*regexp.Regexp) bool {
-	for _, v := range blacklist {
+func listed(path string, list []*regexp.Regexp) bool {
+	for _, v := range list {
 		if v.MatchString(path) {
 			return true
 		}
@@ -98,6 +115,9 @@ func blacklisted(path string, blacklist []*regexp.Regexp) bool {
 }
 
 func str2RE(vs []string) ([]*regexp.Regexp, error) {
+	if len(vs) == 0 {
+		return nil, nil
+	}
 	var (
 		err error
 		o   = make([]*regexp.Regexp, len(vs))
@@ -117,7 +137,50 @@ func str2RE(vs []string) ([]*regexp.Regexp, error) {
 	return o, nil
 }
 
-// Error stores information about a deprecated import in a Go file.
+func includeStd(list []string) ([]string, error) {
+	if len(list) == 0 {
+		return list, nil
+	}
+	pkgs, err := std()
+	if err != nil {
+		return nil, err
+	}
+	return append(list, pkgs...), nil
+}
+
+// str returns a slice of patterns matching the standard library.
+func std() ([]string, error) {
+	var pkgs []string
+
+	// Exclude GOPATH.
+	ctx := build.Default
+	ctx.GOPATH = ""
+	for _, root := range ctx.SrcDirs() {
+		err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if info.IsDir() {
+				switch info.Name() {
+				case "builtin", "cmd", "vendor", "internal", "testdata":
+					return filepath.SkipDir
+				}
+				path, err := filepath.Rel(root, path)
+				if err != nil {
+					return err
+				}
+				if path != "." {
+					pkgs = append(pkgs, filepath.ToSlash(path))
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return pkgs, nil
+}
+
+// Error stores information about a disallowed import in a Go file.
 type Error struct {
 	File    string
 	Imports []string
@@ -125,7 +188,7 @@ type Error struct {
 
 func (e Error) Error() string {
 	return fmt.Sprintf(
-		"%s: deprecated imports: %v",
+		"%s: disallowed imports: %v",
 		e.File,
 		strings.Join(e.Imports, ", "),
 	)

--- a/imports/imports.go
+++ b/imports/imports.go
@@ -148,7 +148,7 @@ func includeStd(list []string) ([]string, error) {
 	return append(list, pkgs...), nil
 }
 
-// str returns a slice of patterns matching the standard library.
+// std returns a slice of patterns matching the standard library.
 func std() ([]string, error) {
 	var pkgs []string
 

--- a/imports/imports.go
+++ b/imports/imports.go
@@ -143,6 +143,21 @@ func includeStd(list []string) ([]string, error) {
 	if len(list) == 0 {
 		return list, nil
 	}
+
+	wanted := true
+	for i := 0; i < len(list); {
+		if list[i] != "-std" {
+			i++
+			continue
+		}
+		wanted = false
+		list[i] = list[len(list)-1]
+		list = list[:len(list)-1]
+	}
+	if !wanted {
+		return list, nil
+	}
+
 	pkgs, err := std()
 	if err != nil {
 		return nil, err

--- a/imports/imports_test.go
+++ b/imports/imports_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"go/token"
 	"reflect"
+	"regexp"
 	"testing"
 )
 
@@ -16,68 +17,138 @@ var blacklist = []string{
 	"math/rand",           // prefer golang.org/x/exp/rand
 }
 
+var checkTests = []struct {
+	whitelist, blacklist []string
+
+	pkg string
+	err error
+}{
+	{
+		pkg: "math/rand",
+		err: Error{
+			File:    "file.go",
+			Imports: []string{"math/rand"},
+		},
+	},
+	{
+		pkg: "math/rands",
+		err: nil,
+	},
+	{
+		pkg: "math",
+		err: nil,
+	},
+	{
+		blacklist: blacklist,
+		pkg:       "math/rand",
+		err: Error{
+			File:    "file.go",
+			Imports: []string{"math/rand"},
+		},
+	},
+	{
+		blacklist: blacklist,
+		pkg:       "math",
+		err:       nil,
+	},
+	{
+		blacklist: blacklist,
+		pkg:       "github.com/gonum/",
+		err: Error{
+			File:    "file.go",
+			Imports: []string{"github.com/gonum/"},
+		},
+	},
+	{
+		blacklist: blacklist,
+		pkg:       "github.com/gonum/floats",
+		err: Error{
+			File:    "file.go",
+			Imports: []string{"github.com/gonum/floats"},
+		},
+	},
+	{
+		blacklist: blacklist,
+		pkg:       "github.com/gonum/plot",
+		err: Error{
+			File:    "file.go",
+			Imports: []string{"github.com/gonum/plot"},
+		},
+	},
+	{
+		blacklist: blacklist,
+		pkg:       "gonum.org/v1/gonum/floats",
+		err:       nil,
+	},
+	{
+		blacklist: blacklist,
+		pkg:       "gonum.org/v1/plot",
+		err:       nil,
+	},
+	{
+		blacklist: blacklist,
+		pkg:       "github.com/gonumnum/floats",
+		err:       nil,
+	},
+	{
+		whitelist: []string{"-std", "golang.org/x/exp/rand"}, // exclude std for testing.
+		pkg:       "math/rand",
+		err: Error{
+			File:    "file.go",
+			Imports: []string{"math/rand"},
+		},
+	},
+	{
+		whitelist: []string{"pkg"},
+		blacklist: []string{"math/rand"},
+		pkg:       "math/rand",
+		err: Error{
+			File:    "file.go",
+			Imports: []string{"math/rand"},
+		},
+	},
+	{
+		whitelist: []string{"pkg"},
+		pkg:       "os",
+		err:       nil,
+	},
+	{
+		whitelist: []string{"-std", "pkg"}, // exclude std for testing.
+		pkg:       "os",
+		err: Error{
+			File:    "file.go",
+			Imports: []string{"os"},
+		},
+	},
+}
+
 func TestCheck(t *testing.T) {
-	blacklist, err := str2RE(blacklist)
-	if err != nil {
-		t.Fatal(err)
-	}
 	fset := token.NewFileSet()
-	for _, tc := range []struct {
-		pkg string
-		err error
-	}{
-		{
-			pkg: "math/rand",
-			err: Error{
-				File:    "file.go",
-				Imports: []string{"math/rand"},
-			},
-		},
-		{
-			pkg: "math/rands",
-			err: nil,
-		},
-		{
-			pkg: "math",
-			err: nil,
-		},
-		{
-			pkg: "github.com/gonum/",
-			err: Error{
-				File:    "file.go",
-				Imports: []string{"github.com/gonum/"},
-			},
-		},
-		{
-			pkg: "github.com/gonum/floats",
-			err: Error{
-				File:    "file.go",
-				Imports: []string{"github.com/gonum/floats"},
-			},
-		},
-		{
-			pkg: "github.com/gonum/plot",
-			err: Error{
-				File:    "file.go",
-				Imports: []string{"github.com/gonum/plot"},
-			},
-		},
-		{
-			pkg: "gonum.org/v1/gonum/floats",
-			err: nil,
-		},
-		{
-			pkg: "gonum.org/v1/plot",
-			err: nil,
-		},
-		{
-			pkg: "github.com/gonumnum/floats",
-			err: nil,
-		},
-	} {
+	var err error
+	for _, tc := range checkTests {
+		whitelist := tc.whitelist
+		if len(whitelist) != 0 && whitelist[0] != "-std" {
+			whitelist, err = includeStd(whitelist)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		var whitepat, blackpat []*regexp.Regexp
+		if len(tc.whitelist) != 0 {
+			whitepat, err = str2RE(whitelist)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		if len(tc.blacklist) != 0 {
+			blackpat, err = str2RE(tc.blacklist)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
 		t.Run("", func(t *testing.T) {
 			src := fmt.Sprintf("package foo\nimport _ %q\n", tc.pkg)
-			err := checkImports(fset, []byte(src), "file.go", blacklist)
+			err := checkImports(fset, []byte(src), "file.go", whitepat, blackpat)
 			if !reflect.DeepEqual(err, tc.err) {
 				t.Fatalf("error\ngot= %v\nwant=%v", err, tc.err)
 			}

--- a/imports/imports_test.go
+++ b/imports/imports_test.go
@@ -126,14 +126,10 @@ var checkTests = []struct {
 
 func TestCheck(t *testing.T) {
 	fset := token.NewFileSet()
-	var err error
 	for _, tc := range checkTests {
-		whitelist := tc.whitelist
-		if len(whitelist) != 0 && whitelist[0] != "-std" {
-			whitelist, err = includeStd(whitelist)
-			if err != nil {
-				t.Fatal(err)
-			}
+		whitelist, err := includeStd(tc.whitelist)
+		if err != nil {
+			t.Fatal(err)
 		}
 		var whitepat, blackpat []*regexp.Regexp
 		if len(tc.whitelist) != 0 {

--- a/imports/imports_test.go
+++ b/imports/imports_test.go
@@ -25,10 +25,7 @@ var checkTests = []struct {
 }{
 	{
 		pkg: "math/rand",
-		err: Error{
-			File:    "file.go",
-			Imports: []string{"math/rand"},
-		},
+		err: nil,
 	},
 	{
 		pkg: "math/rands",
@@ -45,6 +42,11 @@ var checkTests = []struct {
 			File:    "file.go",
 			Imports: []string{"math/rand"},
 		},
+	},
+	{
+		blacklist: blacklist,
+		pkg:       "math/rands",
+		err:       nil,
 	},
 	{
 		blacklist: blacklist,


### PR DESCRIPTION
This adds whitelist/blacklist handling. I'm not sure about the approach to std; at the moment it adds std to the whitelist if there is one. The two other options are to have pseudo-packages to specify inclusion or exclusion of std ("std" and "-std" respectively). I think requiring "std" to be added for whitelisting is probably too onerous, so that just leaves a "-std" for cases where std should be removed from the whitelist,... or just leaving it how it is. Thoughts?

Please take a look.

Closes #4.
<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
